### PR TITLE
fix: missing id param in delete

### DIFF
--- a/specification.yml
+++ b/specification.yml
@@ -83,6 +83,12 @@ paths:
         Removes the todo matching the given id.
       tags:
         - todos
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         '200':
           description: OK


### PR DESCRIPTION
Added the missing id param to the delete to allow the specification to be used as is.

As part of the internship test this causes confusion and the cases for the specification being broken in a work environment is vastly outweighed by people not following the specification, which would be a better task to test